### PR TITLE
fixed deploy error

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -41,5 +41,5 @@ jobs:
             --platform=managed \
             --region=us-central1 \
             --allow-unauthenticated \
-            --add-cloudsql-instances=shiftsl-453509:asia-south1:shiftsl \
+            --add-cloudsql-instances=${{ secrets.CLOUD_SQL_INSTANCE_NAME }} \
             --set-startup-probe-tcp-socket-port=8080 # Explicitly set TCP probe on 8080 (optional, as it's default)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,4 +40,6 @@ jobs:
             --image=us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/shiftsl-backend/spring-app \
             --platform=managed \
             --region=us-central1 \
-            --allow-unauthenticated
+            --allow-unauthenticated \
+            --add-cloudsql-instances=shiftsl-453509:asia-south1:shiftsl \
+            --set-startup-probe-tcp-socket-port=8080 # Explicitly set TCP probe on 8080 (optional, as it's default)

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -4,3 +4,6 @@ spring.datasource.password=${env.DATABASE_PWD}
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=update
+
+server.address=0.0.0.0
+server.port=${PORT:8080}


### PR DESCRIPTION
This pull request introduces changes to improve the deployment configuration and application properties for better compatibility and explicit settings. The most important changes include adding Cloud SQL instance binding and startup probe configuration in the CI/CD workflow, and explicitly setting the server address and port in the development application properties.

### Deployment Configuration Updates:
* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L43-R45): Added `--add-cloudsql-instances` to bind the Cloud SQL instance `shiftsl-453509:asia-south1:shiftsl` and explicitly set the startup probe TCP socket port to `8080` for the deployed application.

### Application Properties Enhancements:
* [`src/main/resources/application-dev.properties`](diffhunk://#diff-cbee934a0dc2d724591feb74d9e4200e997b60b1f2b2a41b51336a0c83ab42b9R7-R9): Added `server.address=0.0.0.0` and `server.port=${PORT:8080}` to explicitly configure the server address and port for development environments.