### PR TITLE
graph QL - ward

### DIFF
--- a/src/main/java/com/shiftsl/backend/repo/UserRepo.java
+++ b/src/main/java/com/shiftsl/backend/repo/UserRepo.java
@@ -4,12 +4,10 @@ import com.shiftsl.backend.model.Role;
 import com.shiftsl.backend.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.graphql.data.GraphQlRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
-@Repository
 @GraphQlRepository
 public interface UserRepo extends JpaRepository<User, Long> {
     Optional<User> findByPhoneNo(String phoneNo);

--- a/src/main/java/com/shiftsl/backend/repo/WardRepo.java
+++ b/src/main/java/com/shiftsl/backend/repo/WardRepo.java
@@ -2,11 +2,13 @@ package com.shiftsl.backend.repo;
 
 import com.shiftsl.backend.model.Ward;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.graphql.data.GraphQlRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
+@GraphQlRepository
 public interface WardRepo extends JpaRepository<Ward, Long> {
     Optional<Ward> findByName(String name);
 }

--- a/src/main/java/com/shiftsl/backend/repo/WardRepo.java
+++ b/src/main/java/com/shiftsl/backend/repo/WardRepo.java
@@ -3,12 +3,12 @@ package com.shiftsl.backend.repo;
 import com.shiftsl.backend.model.Ward;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.graphql.data.GraphQlRepository;
-import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
-@Repository
 @GraphQlRepository
 public interface WardRepo extends JpaRepository<Ward, Long> {
     Optional<Ward> findByName(String name);
+    List<Ward> findByWardAdmin_Id(Long wardAdminId);
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -17,5 +17,7 @@ enum Role {
 }
 
 type Query {
-    user(id: ID!): User
+    users: [User]
+    userByID(id: ID!): User
+    userByRole(role: Role!): [User]
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -26,4 +26,6 @@ type Query {
     users: [User]
     userByID(id: ID!): User
     userByRole(role: Role!): [User]
+    ward: [Ward]
+    wardById(id: ID!): Ward
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -9,6 +9,12 @@ type User {
   role: Role!
 }
 
+type Ward {
+    id: ID!
+    name: String
+    wardAdmin: User!
+}
+
 enum Role {
   HR_ADMIN
   WARD_ADMIN

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -23,9 +23,13 @@ enum Role {
 }
 
 type Query {
-    users: [User]
-    userByID(id: ID!): User
-    userByRole(role: Role!): [User]
-    ward: [Ward]
-    wardById(id: ID!): Ward
+    # User Queries
+    users: [User!]! # List of non-null Users, and the list itself is non-null
+    userByID(id: ID!): User # Returns a single User by ID
+    userByRole(role: Role!): [User!]! # Returns a list of non-null Users by Role
+
+    # Ward Queries
+    wards: [Ward!]! # List of non-null Wards, and the list itself is non-null
+    wardById(id: ID!): Ward # Returns a single Ward by ID
+    wardByAdminId(wardAdminId: ID!): [Ward!]! # Returns a list of non-null Wards
 }


### PR DESCRIPTION
This pull request introduces changes to enhance GraphQL support in the backend by replacing `@Repository` annotations with `@GraphQlRepository`, adding new GraphQL types and queries, and extending repository functionality. Below are the most important changes grouped by theme:

### GraphQL Integration:

* Replaced `@Repository` with `@GraphQlRepository` in `UserRepo` and `WardRepo` to align with the GraphQL data repository standard. (`src/main/java/com/shiftsl/backend/repo/UserRepo.java`, `src/main/java/com/shiftsl/backend/repo/WardRepo.java`) [[1]](diffhunk://#diff-44470a80ea9a48a7a8f34ab2233cda65ac91def9db8171e90920e7b0d234836fL7-L12) [[2]](diffhunk://#diff-611b61e78b74f01cafd4357cca2998efd641712aebec02ba46915b8beae8002cL5-R13)

* Added a new `Ward` type in the GraphQL schema to represent wards, including fields `id`, `name`, and `wardAdmin`. (`src/main/resources/graphql/schema.graphqls`)

### Query Enhancements:

* Expanded the `Query` type in the GraphQL schema to include:
  - Queries for fetching all users (`users`) or users by role (`userByRole`).
  - Queries for fetching all wards (`wards`), wards by ID (`wardById`), or wards by admin ID (`wardByAdminId`). (`src/main/resources/graphql/schema.graphqls`)

### Repository Updates:

* Extended `WardRepo` to include a method `findByWardAdmin_Id(Long wardAdminId)` for fetching wards based on the admin ID. (`src/main/java/com/shiftsl/backend/repo/WardRepo.java`)