### PR TITLE
graphql ward controller created

### DIFF
--- a/src/main/java/com/shiftsl/backend/Controller/WardController_GraphQL.java
+++ b/src/main/java/com/shiftsl/backend/Controller/WardController_GraphQL.java
@@ -1,0 +1,30 @@
+package com.shiftsl.backend.Controller;
+
+import java.util.List;
+
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import com.shiftsl.backend.Service.WardService;
+import com.shiftsl.backend.model.Ward;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class WardController_GraphQL {
+
+    private final WardService wardService;
+
+    @QueryMapping
+    public List<Ward> wards(){
+        return wardService.getWardList();
+    }
+
+    @QueryMapping
+    public Ward wardById(@Argument Long id){
+        return wardService.getWardByID(id);
+    }
+    
+}

--- a/src/main/java/com/shiftsl/backend/repo/WardRepo.java
+++ b/src/main/java/com/shiftsl/backend/repo/WardRepo.java
@@ -2,12 +2,12 @@ package com.shiftsl.backend.repo;
 
 import com.shiftsl.backend.model.Ward;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.graphql.data.GraphQlRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
-@GraphQlRepository
+@Repository
 public interface WardRepo extends JpaRepository<Ward, Long> {
     Optional<Ward> findByName(String name);
     List<Ward> findByWardAdmin_Id(Long wardAdminId);

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -40,12 +40,10 @@ type Query {
     # Returns a list of non-null Users by Role
     userByRole(role: Role!): [User!]!
 
-    # # Returns a list of all Wards
-    # wards: [Ward!]!
-    # # Returns a single Ward by ID
-    # wardById(id: ID!): Ward
-    # # Returns a list wards by ward admin ID
-    # wardByAdminId(wardAdminId: ID!): [Ward!]!
+    # Returns a list of all Wards
+    wards: [Ward!]!
+    # Returns a single Ward by ID
+    wardById(id: ID!): Ward
 
     # # Returns a list of all shifts
     # shifts: [Shift!]!


### PR DESCRIPTION
This pull request introduces GraphQL support for querying Ward data in the backend. It includes the addition of a new GraphQL controller, updates to the repository annotations, and modifications to the GraphQL schema to expose the new queries.

### GraphQL Support for Wards:

* **New GraphQL Controller**: Added `WardController_GraphQL` to handle GraphQL queries for fetching all wards (`wards`) and a single ward by ID (`wardById`). (`src/main/java/com/shiftsl/backend/Controller/WardController_GraphQL.java`)

* **Repository Annotation Update**: Replaced the `@GraphQlRepository` annotation with `@Repository` in the `WardRepo` interface to align with standard repository conventions. (`src/main/java/com/shiftsl/backend/repo/WardRepo.java`)

* **GraphQL Schema Updates**: Un-commented and updated the GraphQL schema to include the `wards` and `wardById` queries, making them available for use. (`src/main/resources/graphql/schema.graphqls`)