### PR TITLE
graphQL setup finished for shift controller

### DIFF
--- a/src/main/java/com/shiftsl/backend/Controller/LeaveController_GraphQL.java
+++ b/src/main/java/com/shiftsl/backend/Controller/LeaveController_GraphQL.java
@@ -1,0 +1,35 @@
+package com.shiftsl.backend.Controller;
+
+import java.util.List;
+
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import com.shiftsl.backend.Service.LeaveService;
+import com.shiftsl.backend.model.Leave;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class LeaveController_GraphQL {
+
+    private final LeaveService leaveService;
+
+    @QueryMapping
+    public List<Leave> leaves(){
+        return leaveService.getLeaves();
+    }
+
+    @QueryMapping
+    public Leave leaveByID(@Argument Long id){
+        return leaveService.getLeave(id);
+    }
+
+    @QueryMapping
+    public List<Leave>leavesByDoctorsID(@Argument Long id){
+        return leaveService.getLeaveByDoctor(id);
+    }
+    
+}

--- a/src/main/java/com/shiftsl/backend/Controller/ShiftController_GraphQL.java
+++ b/src/main/java/com/shiftsl/backend/Controller/ShiftController_GraphQL.java
@@ -1,0 +1,35 @@
+package com.shiftsl.backend.Controller;
+
+import java.util.List;
+
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import com.shiftsl.backend.Service.ShiftService;
+import com.shiftsl.backend.model.Shift;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class ShiftController_GraphQL {
+
+    private final ShiftService shiftService;
+
+    @QueryMapping
+    public List<Shift> shifts(){
+        return shiftService.getAllShifts();
+    }
+
+    @QueryMapping
+    public Shift shiftByID(@Argument Long id){
+        return shiftService.getShiftByID(id);
+    }
+    
+    @QueryMapping
+    public List<Shift> shiftsByDoctorsID(@Argument Long id){
+        return shiftService.getShiftsForDoctor(id);
+    }
+
+}

--- a/src/main/java/com/shiftsl/backend/Service/LeaveService.java
+++ b/src/main/java/com/shiftsl/backend/Service/LeaveService.java
@@ -71,6 +71,6 @@ public class LeaveService {
     }
 
     public List<Leave> getLeaveByDoctor(Long doctorID) {
-        return leaveRepo.findByDoctors_Id(doctorID);
+        return leaveRepo.findByDoctorId(doctorID);
     }
 }

--- a/src/main/java/com/shiftsl/backend/Service/LeaveService.java
+++ b/src/main/java/com/shiftsl/backend/Service/LeaveService.java
@@ -71,6 +71,6 @@ public class LeaveService {
     }
 
     public List<Leave> getLeaveByDoctor(Long doctorID) {
-        return leaveRepo.findByDoctorId(doctorID);
+        return leaveRepo.findByDoctors_Id(doctorID);
     }
 }

--- a/src/main/java/com/shiftsl/backend/model/Leave.java
+++ b/src/main/java/com/shiftsl/backend/model/Leave.java
@@ -10,7 +10,7 @@ public class Leave {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long ID;
+    private Long id;
 
     @Enumerated(EnumType.STRING)
     private LeaveType type;

--- a/src/main/java/com/shiftsl/backend/repo/LeaveRepo.java
+++ b/src/main/java/com/shiftsl/backend/repo/LeaveRepo.java
@@ -1,7 +1,6 @@
 package com.shiftsl.backend.repo;
 
 import com.shiftsl.backend.model.Leave;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +9,6 @@ import java.util.List;
 @Repository
 public interface LeaveRepo extends JpaRepository<Leave, Long> {
 
-    List<Leave> findByDoctors_Id(Long doctorId);
+    List<Leave> findByDoctorId(Long doctorId);
     
 }

--- a/src/main/java/com/shiftsl/backend/repo/LeaveRepo.java
+++ b/src/main/java/com/shiftsl/backend/repo/LeaveRepo.java
@@ -1,6 +1,7 @@
 package com.shiftsl.backend.repo;
 
 import com.shiftsl.backend.model.Leave;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +10,6 @@ import java.util.List;
 @Repository
 public interface LeaveRepo extends JpaRepository<Leave, Long> {
 
-    List<Leave> findByDoctorId(Long doctorId);
+    List<Leave> findByDoctors_Id(Long doctorId);
+    
 }

--- a/src/main/java/com/shiftsl/backend/repo/ShiftRepo.java
+++ b/src/main/java/com/shiftsl/backend/repo/ShiftRepo.java
@@ -6,14 +6,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.graphql.data.GraphQlRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 import java.time.LocalDateTime;
 
-@GraphQlRepository
+@Repository
 public interface ShiftRepo extends JpaRepository<Shift, Long> {
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT s FROM Shift s WHERE s.id = :shiftID")
     Optional<Shift> findShiftWithLock(@Param("shiftID") Long shiftID);
@@ -30,4 +31,5 @@ public interface ShiftRepo extends JpaRepository<Shift, Long> {
     List<Shift> findByDoctors_Id(Long doctorId);
 
     List<Shift> findByStartTimeBetween(LocalDateTime start, LocalDateTime end);
+    
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -71,4 +71,11 @@ type Query {
     shiftByID(id: ID!): Shift
     # Returns a list of shifts by doctor ID
     shiftsByDoctorsID(id: ID!): [Shift]!
+
+    # Returns a list of all leaves
+    leaves: [Leave]!
+    # Returns a single leave by ID
+    leaveByID(id: ID!): Leave
+    # Returns a list of leaves by doctor ID
+    leavesByDoctorsID(id: ID!): [Leave]!
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -25,6 +25,26 @@ type Shift {
   doctors: [User!]!
 }
 
+type Leave {
+  id: ID!
+  leaveType: LeaveType!
+  cause: String
+  shift: Shift!
+  doctor: User!
+  status: Status!
+}
+
+enum Status {
+  PENDING
+  APPROVED
+  REJECTED
+}
+
+enum LeaveType {
+  CASUAL
+  SICK
+}
+
 enum Role {
   HR_ADMIN
   WARD_ADMIN

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -45,10 +45,10 @@ type Query {
     # Returns a single Ward by ID
     wardById(id: ID!): Ward
 
-    # # Returns a list of all shifts
-    # shifts: [Shift!]!
-    # # Returns a single shift by ID
-    # shiftByID(id: ID!): Shift
-    # # Returns a list of shifts by doctor ID
-    # shiftsByDoctorsID(doctorId: ID!): [Shift]!
+    # Returns a list of all shifts
+    shifts: [Shift!]!
+    # Returns a single shift by ID
+    shiftByID(id: ID!): Shift
+    # Returns a list of shifts by doctor ID
+    shiftsByDoctorsID(id: ID!): [Shift]!
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -27,7 +27,7 @@ type Shift {
 
 type Leave {
   id: ID!
-  leaveType: LeaveType!
+  type: LeaveType!
   cause: String
   shift: Shift!
   doctor: User!

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -10,19 +10,19 @@ type User {
 }
 
 type Ward {
-    id: ID!
-    name: String
-    wardAdmin: User!
+  id: ID!
+  name: String
+  wardAdmin: User!
 }
 
 type Shift {
-    id: ID!
-    totalDoctors: Int!
-    noOfDoctors: Int!
-    startTime: String!
-    endTime: String!
-    ward: Ward!
-    doctors: [User!]!
+  id: ID!
+  totalDoctors: Int!
+  noOfDoctors: Int!
+  startTime: String!
+  endTime: String!
+  ward: Ward!
+  doctors: [User!]!
 }
 
 enum Role {


### PR DESCRIPTION
This pull request introduces GraphQL support for managing shifts in the backend. It includes the addition of a new GraphQL controller, updates to the repository layer, and corresponding schema changes. The most important changes are grouped below by theme:

### GraphQL Controller Implementation:
* Added `ShiftController_GraphQL` to handle GraphQL queries for shifts, including fetching all shifts, a shift by its ID, and shifts by a doctor's ID. (`src/main/java/com/shiftsl/backend/Controller/ShiftController_GraphQL.java`)

### Repository Updates:
* Replaced the `@GraphQlRepository` annotation with `@Repository` in `ShiftRepo` to align with standard Spring Data JPA practices. (`src/main/java/com/shiftsl/backend/repo/ShiftRepo.java`)
* Added a missing newline at the end of the `ShiftRepo` interface for better readability. (`src/main/java/com/shiftsl/backend/repo/ShiftRepo.java`)

### GraphQL Schema Changes:
* Updated the GraphQL schema to define queries for fetching all shifts, a shift by ID, and shifts by a doctor's ID. These queries were previously commented out and are now fully implemented. (`src/main/resources/graphql/schema.graphqls`)