### PR TITLE
updated error handling and log levels for ShiftService

### DIFF
--- a/src/test/java/com/shiftsl/backend/unittests/Service/LeaveServiceTest.java
+++ b/src/test/java/com/shiftsl/backend/unittests/Service/LeaveServiceTest.java
@@ -48,7 +48,6 @@ public class LeaveServiceTest {
     @Mock
     private LeaveDTO testLeaveDTO;
 
-//    private ArgumentCaptor<Leave> captor = ArgumentCaptor.forClass(Leave.class);
     private ArgumentCaptor<Leave> captor;
 
     private static final Long ID = 123456L;
@@ -130,7 +129,7 @@ public class LeaveServiceTest {
         when(shiftService.getShiftByID(ID)).thenReturn(testShift);
         when(leaveRepo.save(any(Leave.class))).thenReturn(testLeave);
 
-        Leave result = underTest.requestLeave(testLeaveDTO);
+        underTest.requestLeave(testLeaveDTO);
 
         verify(leaveRepo).save(captor.capture());
         verify(userService).getUserById(ID);
@@ -163,7 +162,6 @@ public class LeaveServiceTest {
 
     @Test
     void rejectTest() {
-//        ArgumentCaptor<Leave> captor = ArgumentCaptor.forClass(Leave.class);
         when(leaveRepo.findById(ID)).thenReturn(Optional.of(testLeave));
         when(leaveRepo.save(any(Leave.class))).thenReturn(testLeave);
         String result = underTest.reject(ID);
@@ -188,7 +186,6 @@ public class LeaveServiceTest {
     @Order(2)
     void approveTest() {
         testShift = Mockito.mock(Shift.class);
-//        ArgumentCaptor<Leave> captor = ArgumentCaptor.forClass(Leave.class);
         when(shiftService.getShiftWithLock(2L)).thenReturn(testShift);
         when(testShift.getDoctors()).thenReturn(testDoctors);
         when(shiftService.updateShiftByID(testShift)).thenReturn(testShift);


### PR DESCRIPTION
## claimShift method updates
- Updated error handling in claim shift method to help with separate test cases and useful messages based on exception, for runtime exceptions and threading exception separately.
- usage of method level variable to store error message and format the message based on exception.

## general changes
- Changed the log level from error to warn for logs that weren't an anomaly like row not being in the database.
- Removed commented out lines of code in LeaveServiceTest class.